### PR TITLE
Remove devices init

### DIFF
--- a/include/Application.hpp
+++ b/include/Application.hpp
@@ -62,7 +62,6 @@ public:
     lug::Graphics::Resource::SharedPtr<lug::Graphics::Render::Texture> _githubLogo;
 
 private:
-    bool initDevice(lug::Graphics::Vulkan::PhysicalDeviceInfo* choosenDevice);
     bool loadFonts();
     bool loadImages(lug::Graphics::Renderer* renderer);
     lug::Graphics::Resource::SharedPtr<lug::Graphics::Render::Texture> buildImage(lug::Graphics::Renderer* renderer, std::string fileName);

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -66,19 +66,11 @@ Application::~Application() {
 }
 
 bool Application::init(int argc, char* argv[]) {
-    if (!lug::Core::Application::beginInit(argc, argv)) {
+    if (!lug::Core::Application::init(argc, argv)) {
         return false;
     }
 
     lug::Graphics::Renderer* renderer = _graphics.getRenderer();
-
-    lug::Graphics::Vulkan::Renderer* vkRender = static_cast<lug::Graphics::Vulkan::Renderer*>(renderer);
-
-    for (auto& choosedDevice : vkRender->getPhysicalDeviceInfos()) {
-        if (!initDevice(&choosedDevice)) {
-            LUG_LOG.warn("Can't initialize the engine for the device {}", choosedDevice.properties.deviceName);
-        }
-    }
 
     // Create camera
     {
@@ -111,23 +103,6 @@ bool Application::init(int argc, char* argv[]) {
     menuState = std::make_shared<ModelsState>(*this);
     pushState(menuState);
 
-    return true;
-}
-
-bool Application::initDevice(lug::Graphics::Vulkan::PhysicalDeviceInfo* choosenDevice) {
-    lug::Graphics::Renderer* renderer = _graphics.getRenderer();
-    lug::Graphics::Vulkan::Renderer* vkRender = static_cast<lug::Graphics::Vulkan::Renderer*>(renderer);
-
-    vkRender->getPreferences().device = choosenDevice;
-
-    if (!lug::Core::Application::finishInit()) {
-        return false;
-    }
-
-    const lug::Graphics::Vulkan::PhysicalDeviceInfo *physicalDeviceInfo = vkRender->getPhysicalDeviceInfo();
-    if (physicalDeviceInfo == NULL) {
-        return false;
-    }
     return true;
 }
 


### PR DESCRIPTION
We don't need to initialize the devices in LugBench.
Let the renderer choose the device.